### PR TITLE
Remediate ESLint dependency alerts for issue #18

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@typescript-eslint/parser": "^5.45.0",
         "@vscode/test-electron": "^2.2.0",
         "@vscode/vsce": "^3.6.0",
-        "eslint": "^8.28.0",
+        "eslint": "^8.57.1",
         "typescript": "^4.9.4"
       },
       "engines": {
@@ -2632,9 +2632,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
     },
@@ -3724,9 +3724,9 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -124,13 +124,34 @@
     "@types/node": "16.x",
     "@typescript-eslint/eslint-plugin": "^5.45.0",
     "@typescript-eslint/parser": "^5.45.0",
-    "eslint": "^8.28.0",
+    "eslint": "^8.57.1",
     "typescript": "^4.9.4",
     "@vscode/test-electron": "^2.2.0",
     "@vscode/vsce": "^3.6.0"
   },
   "overrides": {
     "undici": "^7.24.0",
-    "qs": "^6.14.2"
+    "qs": "^6.14.2",
+    "flat-cache": {
+      "flatted": "^3.4.2"
+    },
+    "@vscode/vsce": {
+      "minimatch": "^3.1.5",
+      "glob": {
+        "minimatch": "^10.2.5"
+      }
+    },
+    "eslint": {
+      "minimatch": "^3.1.5"
+    },
+    "@eslint/eslintrc": {
+      "minimatch": "^3.1.5"
+    },
+    "@humanwhocodes/config-array": {
+      "minimatch": "^3.1.5"
+    },
+    "glob@7": {
+      "minimatch": "^3.1.5"
+    }
   }
 }


### PR DESCRIPTION
## Summary

- bump the declared ESLint version to the current compatible 8.x line
- add scoped npm overrides for `flatted` and vulnerable `minimatch` 3.x resolution paths
- regenerate `package-lock.json` and verify linting, compile, and packaging still work

## Verification

- `npm ls eslint flatted minimatch`
- `npm run lint`
- `npm run compile`
- `npm run package`
- `npm audit --json`

## Notes

- `flatted` now resolves to `3.4.2`
- vulnerable `minimatch` 3.x paths now resolve to `3.1.5`
- `glob@11` continues to use `minimatch@10.2.5` as intended
- remaining `picomatch` vulnerability work is intentionally left for issue #16
- `ajv`, `brace-expansion`, and `underscore` still appear in `npm audit`, but they are outside the Dependabot alert scope for this issue

Refs #18
