### PR TITLE
Remediate TypeScript ESLint dependency alert for issue #16

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,8 @@
       "devDependencies": {
         "@types/node": "16.x",
         "@types/vscode": "^1.74.0",
-        "@typescript-eslint/eslint-plugin": "^5.45.0",
-        "@typescript-eslint/parser": "^5.45.0",
+        "@typescript-eslint/eslint-plugin": "^5.62.0",
+        "@typescript-eslint/parser": "^5.62.0",
         "@vscode/test-electron": "^2.2.0",
         "@vscode/vsce": "^3.6.0",
         "eslint": "^8.57.1",
@@ -4285,9 +4285,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -122,8 +122,8 @@
   "devDependencies": {
     "@types/vscode": "^1.74.0",
     "@types/node": "16.x",
-    "@typescript-eslint/eslint-plugin": "^5.45.0",
-    "@typescript-eslint/parser": "^5.45.0",
+    "@typescript-eslint/eslint-plugin": "^5.62.0",
+    "@typescript-eslint/parser": "^5.62.0",
     "eslint": "^8.57.1",
     "typescript": "^4.9.4",
     "@vscode/test-electron": "^2.2.0",
@@ -152,6 +152,9 @@
     },
     "glob@7": {
       "minimatch": "^3.1.5"
+    },
+    "micromatch": {
+      "picomatch": "^2.3.2"
     }
   }
 }


### PR DESCRIPTION
## Summary

- align the declared `@typescript-eslint` package versions with the already-resolved `5.62.0` toolchain
- add a scoped override so `micromatch` resolves `picomatch` to the patched `2.3.2` release
- regenerate `package-lock.json` and verify linting, compile, and packaging still work

## Verification

- `npm ls @typescript-eslint/parser @typescript-eslint/eslint-plugin picomatch micromatch`
- `npm run lint`
- `npm run compile`
- `npm run package`
- `npm audit --json`

## Notes

- `picomatch` now resolves to `2.3.2`
- this clears the remaining Dependabot issue grouped under #16
- remaining `npm audit` items are `ajv`, `brace-expansion`, and `underscore`, which are outside the current Dependabot remediation milestone scope

Refs #16
