### PR TITLE
Add .NET 10.0 framework support

### DIFF
--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -76,7 +76,7 @@ Telemetry is anonymous and respects VS Code's global telemetry settings. No sour
 - **Unit tests** for utils (filesystem, dotnet CLI wrappers) where feasible
 - **Manual validation matrix** per release:
   - Platforms: macOS, Windows, Linux
-  - .NET versions: 6.0, 7.0, 8.0, 9.0
+  - .NET versions: 6.0, 7.0, 8.0, 9.0, 10.0
   - Key templates: Console, Web API, Blazor, xUnit, Class Library
 - Test **Git workflows** (local, GitHub CLI, custom remote, none)
 
@@ -114,4 +114,4 @@ This constitution documents the project's design philosophy and technical constr
 2. Approval from maintainer(s)
 3. Update to this document with rationale
 
-**Version**: 1.0.0 | **Ratified**: 2025-12-08 | **Last Amended**: 2025-12-08
+**Version**: 1.0.1 | **Ratified**: 2025-12-08 | **Last Amended**: 2026-04-12

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to the ".NET Project Creator" extension will be documented in this file.
 
+## [Unreleased]
+
+### Added
+- **NET 10.0 Support**: Added .NET 10.0 as a framework option across the scaffold flow and documentation
+- Updated Blazor template mapping to treat .NET 10.0 like the unified .NET 8+ template path
+
+### Changed
+- Updated spec and architecture examples to include .NET 10.0 in supported framework lists
+
 ## [1.4.0] - 2025-10-31
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Version](https://img.shields.io/badge/version-1.4.0-blue.svg)](https://github.com/bdonaldharris/dotnet-project-creator)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 [![VS Code](https://img.shields.io/badge/VS%20Code-1.74.0+-007ACC.svg)](https://code.visualstudio.com/)
-[![.NET](https://img.shields.io/badge/.NET-6.0%20|%207.0%20|%208.0%20|%209.0-512BD4.svg)](https://dotnet.microsoft.com/)
+[![.NET](https://img.shields.io/badge/.NET-6.0%20|%207.0%20|%208.0%20|%209.0%20|%2010.0-512BD4.svg)](https://dotnet.microsoft.com/)
 
 > **Scaffold .NET projects with ease! An intuitive VS Code extension featuring tree view templates, interactive configuration, and hybrid Git integration.**
 
@@ -49,7 +49,7 @@ Create Console apps, Web APIs, Blazor applications, class libraries, and test pr
   - Custom remote URLs
   - No Git (for those who prefer otherwise)
 - 🎨 **12+ Templates** - Covering Console, Web, Blazor, Libraries, and Test projects
-- 🎯 **Framework Flexibility** - Support for .NET 6.0, 7.0, 8.0, and 9.0
+- 🎯 **Framework Flexibility** - Support for .NET 6.0, 7.0, 8.0, 9.0, and 10.0
 - 🔒 **Privacy-First Telemetry** - Anonymous usage analytics (respects VS Code settings)
 
 ---
@@ -89,7 +89,7 @@ npm run compile
 5. Fill in your project details:
    - Project name
    - Target path
-   - Framework version (.NET 6.0 - 9.0)
+   - Framework version (.NET 6.0 - 10.0)
    - Git integration option
 6. Click **Create Project** and watch the magic happen! ✨
 
@@ -110,7 +110,7 @@ When creating a project, customize these settings:
 |--------|-------------|----------|
 | **Project Name** | Your project's identifier | Any valid .NET project name |
 | **Project Path** | Where to create the project | Any writable directory |
-| **Target Framework** | .NET version to target | 6.0, 7.0, 8.0, 9.0 |
+| **Target Framework** | .NET version to target | 6.0, 7.0, 8.0, 9.0, 10.0 |
 | **Create Solution** | Generate a solution file | Yes / No |
 | **Git Integration** | Repository initialization | Local, GitHub, Remote, None |
 | **GitHub Visibility** | Public or private repo | Public / Private (if using GitHub) |
@@ -378,6 +378,9 @@ This extension is licensed under the [MIT License](LICENSE).
 ---
 
 ## 📝 Release Notes
+
+### Unreleased
+- 🔧 .NET 10.0 support
 
 ### v1.4.0 (Latest)
 - 🗂️ Simplified solution layout when "Create solution" is selected:

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -15,9 +15,13 @@ Typical flow:
 
 1. Update your local `staging`.
 2. Create a feature branch from `staging`.
-3. Commit and push the feature branch.
-4. Open a pull request from the feature branch into `staging`.
-5. After validation, open a promotion pull request from `staging` into `main`.
+3. Implement the change and update user-facing docs as part of completion work.
+4. Check whether `README.md` should change whenever an issue affects supported features, workflows, framework versions, configuration, or setup expectations.
+5. Commit and push the feature branch.
+6. Open a pull request from the feature branch into `staging`.
+7. After validation, open a promotion pull request from `staging` into `main`.
+
+For completed issues, treat `README.md` review as part of the definition of done, alongside any needed `CHANGELOG.md` or other documentation updates.
 
 Example:
 

--- a/spec/ARCHITECTURE.md
+++ b/spec/ARCHITECTURE.md
@@ -59,7 +59,7 @@ Template:
   parameters:
     - name: "framework"
       type: "enum"
-      values: ["net6.0", "net7.0", "net8.0", "net9.0"]
+      values: ["net6.0", "net7.0", "net8.0", "net9.0", "net10.0"]
     - name: "solution"
       type: "boolean"
     - name: "gitMode"
@@ -116,7 +116,7 @@ ConfigSchema:
       required: true
     framework:
       type: enum
-      values: ["6.0", "7.0", "8.0", "9.0"]
+      values: ["6.0", "7.0", "8.0", "9.0", "10.0"]
     createSolution:
       type: boolean
     gitMode:

--- a/spec/templates/blazorwasm.yaml
+++ b/spec/templates/blazorwasm.yaml
@@ -17,7 +17,7 @@ template:
       required: true
     framework:
       type: enum
-      values: ["net7.0", "net8.0", "net9.0"]
+      values: ["net7.0", "net8.0", "net9.0", "net10.0"]
       default: "net8.0"
     hosted:
       type: boolean

--- a/spec/templates/console.yaml
+++ b/spec/templates/console.yaml
@@ -17,7 +17,7 @@ template:
       required: true
     framework:
       type: enum
-      values: ["net6.0", "net7.0", "net8.0", "net9.0"]
+      values: ["net6.0", "net7.0", "net8.0", "net9.0", "net10.0"]
       default: "net8.0"
     createSolution:
       type: boolean

--- a/spec/templates/webapi.yaml
+++ b/spec/templates/webapi.yaml
@@ -17,7 +17,7 @@ template:
       required: true
     framework:
       type: enum
-      values: ["net6.0", "net7.0", "net8.0", "net9.0"]
+      values: ["net6.0", "net7.0", "net8.0", "net9.0", "net10.0"]
       default: "net8.0"
     createSolution:
       type: boolean

--- a/src/utils/dotnetCli.ts
+++ b/src/utils/dotnetCli.ts
@@ -29,7 +29,7 @@ export class DotNetCli {
 
     private getTemplateForFramework(templateName: string, framework?: string): string {
         // Map old Blazor templates to new unified template for .NET 8+
-        if (framework && (framework === 'net8.0' || framework === 'net9.0')) {
+        if (framework && (framework === 'net8.0' || framework === 'net9.0' || framework === 'net10.0')) {
             if (templateName === 'blazorserver' || templateName === 'blazorwasm') {
                 return 'blazor';
             }

--- a/src/webview/webviewManager.ts
+++ b/src/webview/webviewManager.ts
@@ -227,6 +227,7 @@ export class WebviewManager {
             <label for="framework">Target Framework</label>
             <select id="framework" name="framework">
                 <option value="">Default</option>
+                <option value="net10.0">NET 10.0</option>
                 <option value="net9.0">NET 9.0</option>
                 <option value="net8.0">NET 8.0</option>
                 <option value="net7.0">NET 7.0</option>


### PR DESCRIPTION
## Summary
- add .NET 10.0 to the framework selector and Blazor template mapping
- update README, changelog, spec templates, and architecture docs to reflect .NET 10.0 support
- document README review as part of the issue completion workflow

Closes #24